### PR TITLE
Adds admin1code to cities.json

### DIFF
--- a/scripts/cities.py
+++ b/scripts/cities.py
@@ -24,7 +24,8 @@ for record in reader:
         'longitude': float(longitude),
         'countrycode': countrycode,
         'population': int(population),
-        'timezone': timezone
+        'timezone': timezone,
+        'admin1code': admin1code,
     }
 
 with open('geonamescache/cities.json', 'w') as f:

--- a/tests/test_geonamescache.py
+++ b/tests/test_geonamescache.py
@@ -65,6 +65,12 @@ class GeonamesCacheTestSuite(unittest.TestCase):
         self.assertEqual(
             2, len(self.geonamescache.get_cities_by_name('Madrid')))
 
+    def test_cities_in_us_states(self):
+        cities = self.geonamescache.get_cities()
+        for gid, name, us_state in (('4164138', 'Miami', 'FL'), ('4525353', 'Springfield', 'OH')):
+            self.assertEqual(name, cities[gid]['name'])
+            self.assertEqual(us_state, cities[gid]['admin1code'])
+
     def test_us_counties_len(self):
         # Make sure there are 3235 counties, which includes Puerto Rico etc.
         us_counties = self.geonamescache.get_us_counties()


### PR DESCRIPTION
In the US, admin1code corresponds to the state code, e.g. "FL" for the
city Miami. This provides a useful correspondence between the methods
`get_cities` and `get_us_states`.

A test has also been added.

The output JSON data has not been rebuilt.