### PR TITLE
Case insensitive search in search_cities function

### DIFF
--- a/geonamescache/__init__.py
+++ b/geonamescache/__init__.py
@@ -79,13 +79,27 @@ class GeonamesCache:
                 self.us_counties, 'us_counties.json')
         return self.us_counties
 
-    def search_cities(self, query, attribute='alternatenames'):
+    def search_cities(self, query, attribute='alternatenames', case_sensitive=True):
         """Search all city records and return list of records, that match query for given attribute."""
 
         results = []
         for key, record in self.get_cities().items():
-            if query in record[attribute]:
-                results.append(record)
+            if case_sensitive:
+                if query in record[attribute]:
+                    results.append(record)
+            else:
+                lower_func = "casefold" if hasattr("", "casefold") else "lower"
+                if isinstance(record[attribute], list):
+                    if any(
+                        getattr(query, lower_func)() == getattr(value, lower_func)()
+                        for value in record[attribute]
+                    ):
+                        results.append(record)
+                elif (
+                    getattr(query, lower_func)()
+                    in getattr(record[attribute], lower_func)()
+                ):
+                    results.append(record)
         return results
 
     def _load_data(self, datadict, datafile):

--- a/tests/test_geonamescache.py
+++ b/tests/test_geonamescache.py
@@ -75,6 +75,21 @@ class GeonamesCacheTestSuite(unittest.TestCase):
         cities = self.geonamescache.search_cities('Kiev')
         self.assertGreaterEqual(len(cities), 1)
 
+    def test_search_cities_case_sensitive(self):
+        cities = self.geonamescache.search_cities('Stoke-On-Trent')
+        self.assertGreaterEqual(len(cities), 0)
+        cities = self.geonamescache.search_cities('Stoke-On-Trent', case_sensitive=False)
+        self.assertGreaterEqual(len(cities), 1)
+
+    def test_search_cities_case_sensitive_with_casefold(self):
+        """Using casefold in python 3 for better case insensitive results
+        Example being Gießen
+        """
+        cities = self.geonamescache.search_cities('Giessen', attribute='name')
+        self.assertGreaterEqual(len(cities), 0)
+        cities = self.geonamescache.search_cities('Giessen', attribute='name', case_sensitive=False)
+        self.assertGreaterEqual(len(cities), 1 if hasattr("", "casefold") else 0)
+
     def test_us_counties_len(self):
         # Make sure there are 3235 counties, which includes Puerto Rico etc.
         us_counties = self.geonamescache.get_us_counties()


### PR DESCRIPTION
Adding the functionality to do case insensitive search in the search_cities function.

If using python3 the function used during comparison will be casefold.
In python2 the function used during comparison will be lower.

Kept the functionality that if it is a string field it will partially match but if it is a list it requires an exact match.