### PR TITLE
Bringing the search_cities behaviour to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ Currently geonamescache provides the following methods, that return dictionaries
 
 In addition you can search for cities by name.
 
-* search\_cities(\'NAME\', case\_sensitive=True)
+* search\_cities(\'NAME\', case\_sensitive=True, contains\_search=True)
 
 This function returns a list of city records that match the given `NAME`.
 
 * By default the `alternatenames` attribute is searched for matches.
 * By default the search is case sensitive, it can be made case insensitive by changing `case_sensitive` to False.
+* By default the search is contains, it can be made exact equality by changing `contains_search` to False.
 
 ## Mappers
 

--- a/geonamescache/__init__.py
+++ b/geonamescache/__init__.py
@@ -72,7 +72,7 @@ class GeonamesCache:
             self.us_counties = self._load_data(self.us_counties, 'us_counties.json')
         return self.us_counties
 
-    def search_cities(self, query, attribute='alternatenames', case_sensitive=True, contains_search=True):
+    def search_cities(self, query, attribute='alternatenames', case_sensitive=False, contains_search=True):
         """Search all city records and return list of records, that match query for given attribute."""
         results = []
         query = (case_sensitive and query) or query.casefold()

--- a/geonamescache/__init__.py
+++ b/geonamescache/__init__.py
@@ -75,14 +75,14 @@ class GeonamesCache:
     def search_cities(self, query, attribute='alternatenames', case_sensitive=True, contains_search=True):
         """Search all city records and return list of records, that match query for given attribute."""
         results = []
-        query = case_sensitive and query or query.casefold()
+        query = (case_sensitive and query) or query.casefold()
         for record in self.get_cities().values():
             record_value = record[attribute]
             if contains_search:
                 if isinstance(record_value, list):
-                    if any(query in (case_sensitive and value or value.casefold()) for value in record_value):
+                    if any(query in ((case_sensitive and value) or value.casefold()) for value in record_value):
                         results.append(record)
-                elif query in (case_sensitive and record_value or record_value.casefold()):
+                elif query in ((case_sensitive and record_value) or record_value.casefold()):
                     results.append(record)
             else:
                 if isinstance(record_value, list):
@@ -92,7 +92,7 @@ class GeonamesCache:
                     else:
                         if any(query == value.casefold() for value in record_value):
                             results.append(record)
-                elif query == (case_sensitive and record_value or record_value.casefold()):
+                elif query == ((case_sensitive and record_value) or record_value.casefold()):
                     results.append(record)
         return results
 

--- a/tests/test_geonamescache.py
+++ b/tests/test_geonamescache.py
@@ -75,34 +75,34 @@ class GeonamesCacheTestSuite(unittest.TestCase):
         self.assertGreaterEqual(len(cities), 1)
 
     def test_search_cities_case_sensitive(self):
+        cities = self.geonamescache.search_cities('Stoke-On-Trent', case_sensitive=True)
+        self.assertEqual(len(cities), 0)
         cities = self.geonamescache.search_cities('Stoke-On-Trent')
-        self.assertGreaterEqual(len(cities), 0)
-        cities = self.geonamescache.search_cities('Stoke-On-Trent', case_sensitive=False)
-        self.assertGreaterEqual(len(cities), 1)
+        self.assertEqual(len(cities), 1)
 
     def test_search_cities_alternatenames_contains_search(self):
         cities = self.geonamescache.search_cities('London')
-        self.assertGreaterEqual(len(cities), 3)
+        self.assertEqual(len(cities), 15)
         cities = self.geonamescache.search_cities('London', contains_search=False)
-        self.assertGreaterEqual(len(cities), 2)
+        self.assertEqual(len(cities), 2)
 
     def test_search_cities_name_contains_search(self):
         cities = self.geonamescache.search_cities('London', 'name')
-        self.assertGreaterEqual(len(cities), 3)
+        self.assertEqual(len(cities), 5)
         cities = self.geonamescache.search_cities('London', 'name', contains_search=False)
-        self.assertGreaterEqual(len(cities), 2)
+        self.assertEqual(len(cities), 2)
 
-    def test_search_cities_alternatenames_contains_search_and_case_insensitive(self):
-        cities = self.geonamescache.search_cities('London', case_sensitive=False)
-        self.assertGreaterEqual(len(cities), 3)
-        cities = self.geonamescache.search_cities('London', case_sensitive=False, contains_search=False)
-        self.assertGreaterEqual(len(cities), 2)
+    def test_search_cities_alternatenames_contains_search_and_case_sensitive(self):
+        cities = self.geonamescache.search_cities('London', case_sensitive=True)
+        self.assertEqual(len(cities), 14)
+        cities = self.geonamescache.search_cities('London', case_sensitive=True, contains_search=False)
+        self.assertEqual(len(cities), 2)
 
-    def test_search_cities_name_contains_search_and_case_insensitive(self):
-        cities = self.geonamescache.search_cities('London', 'name', case_sensitive=False)
-        self.assertGreaterEqual(len(cities), 3)
-        cities = self.geonamescache.search_cities('London', 'name', case_sensitive=False, contains_search=False)
-        self.assertGreaterEqual(len(cities), 2)
+    def test_search_cities_name_contains_search_and_case_sensitive(self):
+        cities = self.geonamescache.search_cities('London', 'name', case_sensitive=True)
+        self.assertEqual(len(cities), 5)
+        cities = self.geonamescache.search_cities('London', 'name', case_sensitive=True, contains_search=False)
+        self.assertEqual(len(cities), 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_geonamescache.py
+++ b/tests/test_geonamescache.py
@@ -80,14 +80,29 @@ class GeonamesCacheTestSuite(unittest.TestCase):
         cities = self.geonamescache.search_cities('Stoke-On-Trent', case_sensitive=False)
         self.assertGreaterEqual(len(cities), 1)
 
-    def test_search_cities_case_sensitive_with_casefold(self):
-        """Using casefold in python 3 for better case insensitive results
-        Example being Gießen
-        """
-        cities = self.geonamescache.search_cities('Giessen', attribute='name')
-        self.assertGreaterEqual(len(cities), 0)
-        cities = self.geonamescache.search_cities('Giessen', attribute='name', case_sensitive=False)
-        self.assertGreaterEqual(len(cities), 1 if hasattr('', 'casefold') else 0)
+    def test_search_cities_alternatenames_contains_search(self):
+        cities = self.geonamescache.search_cities('London')
+        self.assertGreaterEqual(len(cities), 3)
+        cities = self.geonamescache.search_cities('London', contains_search=False)
+        self.assertGreaterEqual(len(cities), 2)
+
+    def test_search_cities_name_contains_search(self):
+        cities = self.geonamescache.search_cities('London', 'name')
+        self.assertGreaterEqual(len(cities), 3)
+        cities = self.geonamescache.search_cities('London', 'name', contains_search=False)
+        self.assertGreaterEqual(len(cities), 2)
+
+    def test_search_cities_alternatenames_contains_search_and_case_insensitive(self):
+        cities = self.geonamescache.search_cities('London', case_sensitive=False)
+        self.assertGreaterEqual(len(cities), 3)
+        cities = self.geonamescache.search_cities('London', case_sensitive=False, contains_search=False)
+        self.assertGreaterEqual(len(cities), 2)
+
+    def test_search_cities_name_contains_search_and_case_insensitive(self):
+        cities = self.geonamescache.search_cities('London', 'name', case_sensitive=False)
+        self.assertGreaterEqual(len(cities), 3)
+        cities = self.geonamescache.search_cities('London', 'name', case_sensitive=False, contains_search=False)
+        self.assertGreaterEqual(len(cities), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bringing the search_cities behaviour to be consistent when looking at list and string attributes. The new default will be contains based searching but can be changed to exact search with the argument contains_search. Also changing the code to use python3 syntax for casing as python 2.7 is no longer supported.