### PR TITLE
Us counties 2020 list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ help:
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-py - remove Python file artifacts"
 	@echo "clean-test - remove test and coverage artifacts"
+	@echo "clean-data - remove all downloaded files in data/"
 
+make_data:
+	mkdir data
 
 data/cities500.txt:
 	curl -o data/cities500.zip http://download.geonames.org/export/dump/cities500.zip
@@ -31,9 +34,9 @@ data/countryInfo.txt:
 	curl -o data/countryInfo.txt http://download.geonames.org/export/dump/countryInfo.txt
 
 data/us_counties.txt:
-	curl -o data/us_counties.txt https://www2.census.gov/geo/docs/reference/codes/files/national_county.txt
+	curl -o data/us_counties.txt https://www2.census.gov/geo/docs/reference/codes2020/national_county2020.txt
 
-dl: data/cities500.txt data/cities1000.txt data/cities5000.txt data/cities15000.txt data/countryInfo.txt data/us_counties.txt
+dl: make_data data/cities500.txt data/cities1000.txt data/cities5000.txt data/cities15000.txt data/countryInfo.txt data/us_counties.txt
 
 json:
 	'./bin/continents.py'
@@ -42,7 +45,10 @@ json:
 	'./bin/us_counties.py'
 	mv data/*.json geonamescache/data/
 
-clean: clean-build clean-py clean-test
+clean: clean-build clean-py clean-test clean-data
+
+clean-data:
+	rm -fr data/
 
 clean-build:
 	rm -fr build/

--- a/bin/us_counties.py
+++ b/bin/us_counties.py
@@ -6,6 +6,7 @@ from pathlib import Path
 p_data = Path('data')
 
 reader = csv.reader(p_data.joinpath('us_counties.txt').open())
+next(reader) # skip header row
 
 state_name_idx = 0
 state_fips_idx = 1
@@ -23,4 +24,5 @@ for line in reader:
         }
     )
 
-p_data.joinpath('us_counties.json').write_text(json.dumps(counties))
+# need ensure_ascii=False to handle special characters (for PR counties)
+p_data.joinpath('us_counties.json').write_text(json.dumps(counties, ensure_ascii=False))

--- a/bin/us_counties.py
+++ b/bin/us_counties.py
@@ -7,6 +7,20 @@ p_data = Path('data')
 
 reader = csv.reader(p_data.joinpath('us_counties.txt').open())
 
-counties = [{'fips': line[1] + line[2], 'name': line[3], 'state': line[0]} for line in reader]
+state_name_idx = 0
+state_fips_idx = 1
+county_fips_idx = 2
+county_name_idx = 4
+
+counties = []
+for line in reader: 
+    current_line = line[0].split("|")
+    counties.append(
+        {
+            'fips': current_line[state_fips_idx] + current_line[county_fips_idx], 
+            'name': current_line[county_name_idx], 
+            'state': current_line[state_name_idx]
+        }
+    )
 
 p_data.joinpath('us_counties.json').write_text(json.dumps(counties))


### PR DESCRIPTION
## Overview
For `data/us_counties.txt`, change the counties URL to use the published 2020 version. This version contains a few changes described [here](https://github.com/yaph/geonamescache/issues/44)

Fixes https://github.com/yaph/geonamescache/issues/44

## Changelog
- Makefile
    - add make_data action. Helped me when running make dl as without this action there will be a file not found error for data/
    - update dl action use use make_data
    - update help action to reference make_data
    - add clean-data action to remove directory. Added this to clean action as well
    - Change data/us_counties.txt action to use new URL
-  bin/us_counties.py
    - Added definitions for what each index references
    - parse new counties file
        - Decided to go with a loop instead of list compression as there is another step required

## Testing
After running `make dl && make json`, the new us_counties.json contains entries for each of the counties mentioned in #44 
Taken by manually scanning us_counties.json
```
{"fips": "02158", "name": "Kusilvak Census Area", "state": "AK"}
{"fips": "30111", "name": "Yellowstone County", "state": "MT"}
{"fips": "46102", "name": "Oglala Lakota County", "state": "SD"}
```