### PR TITLE
fix: use stdlib typing on Python 3.11+ to avoid import deadlock on Python 3.13

### DIFF
--- a/geonamescache/types.py
+++ b/geonamescache/types.py
@@ -1,6 +1,10 @@
+import sys
 from typing import Literal
 
-from typing_extensions import NotRequired, TypedDict
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict
+else:
+    from typing_extensions import NotRequired, TypedDict
 
 GeoNameIdStr = str
 ISOStr = str


### PR DESCRIPTION
## Problem

On Python 3.13, importing `geonamescache` during pytest's test collection phase causes pytest to **hang indefinitely** with zero output. The process never terminates on its own.

### Root cause

`types.py` imports `TypedDict` and `NotRequired` from `typing_extensions`:

```python
from typing_extensions import NotRequired, TypedDict
```

`typing_extensions` 4.x rewrote `TypedDict` to match Python 3.13's new `__annotate__` protocol. This implementation deadlocks inside Python 3.13's import machinery when `geonamescache` is imported transitively during pytest collection (e.g. imported by a utility module that is discovered during test file scanning).

The hang occurs before pytest prints its session header — i.e. during plugin/conftest loading — and was confirmed on Python 3.13.12 with `typing_extensions==4.15.0`. The issue does **not** reproduce on Python 3.11.

## Fix

Use stdlib `typing` on Python ≥ 3.11, where both `TypedDict` (available since 3.8) and `NotRequired` (available since 3.11) are natively present. Fall back to `typing_extensions` only for Python 3.10, which is the minimum supported version per `pyproject.toml`.

```python
if sys.version_info >= (3, 11):
    from typing import NotRequired, TypedDict
else:
    from typing_extensions import NotRequired, TypedDict
```

## Verification

Downgrading to `geonamescache==2.0.0` (which has no `typing_extensions` dependency) immediately unblocked our CI. The fix above is the minimal targeted change to restore Python 3.13 compatibility in 3.0.0.