### PR TITLE
Add get_admin1_codes() for first-level administrative divisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- insertion marker -->
+## [Unreleased]
+
+### Added
+
+- Add `get_admin1_codes()` method returning first-level administrative division data from the GeoNames `admin1CodesASCII.txt` dataset, keyed by `<countrycode>.<admin1code>` (e. g. `US.CA`), which allows resolving the `countrycode`/`admin1code` references stored in city records.
+
 ## [3.0.2](https://github.com/yaph/geonamescache/releases/tag/3.0.2) - 2026-07-28
 
 <small>[Compare with 3.0.1](https://github.com/yaph/geonamescache/compare/3.0.1...3.0.2)</small>

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ dl:
 
 json:
 	mkdir -p geonamescache/data/
+	./bin/admin1.py
 	./bin/continents.py
 	./bin/countries.py
 	./bin/cities.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![image](https://img.shields.io/pypi/v/geonamescache.svg)](https://pypi.python.org/pypi/geonamescache)
 
-A Python library that provides functions to retrieve names, ISO and FIPS codes of continents, countries as well as US states and counties as Python dictionaries. The country and city datasets also include population and geographic data.
+A Python library that provides functions to retrieve names, ISO and FIPS codes of continents, countries and first-level administrative divisions as well as US states and counties as Python dictionaries. The country and city datasets also include population and geographic data.
 
 Geonames data is obtained from [GeoNames](http://www.geonames.org/).
 
@@ -31,12 +31,15 @@ Currently geonamescache provides the following methods, that return dictionaries
 
 * get\_continents()
 * get\_countries()
+* get\_admin1\_codes()
 * get\_us\_states()
 * get\_cities()
 * get\_countries\_by\_names()
 * get\_us\_states\_by\_names()
 * get\_cities\_by\_name(name)
 * get\_us\_counties()
+
+The dictionary returned by `get_admin1_codes()` is keyed by the code `<countrycode>.<admin1code>`, for example `US.CA` for California, which allows resolving the `countrycode` and `admin1code` references stored in city records.
 
 In addition you can search for cities by name.
 

--- a/bin/admin1.py
+++ b/bin/admin1.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import csv
+import json
+from pathlib import Path
+
+p_data = Path('datasets')
+
+admin1 = {}
+
+reader = csv.reader(p_data.joinpath('admin1CodesASCII.txt').open(encoding='utf-8'), 'excel-tab')
+for record in reader:
+    code, name, asciiname, geonameid = record
+
+    # required because used as key
+    if not code:
+        continue
+
+    admin1[code] = {
+        'asciiname': asciiname,
+        'geonameid': int(geonameid) if geonameid else 0,
+        'name': name,
+    }
+
+p_data.joinpath('admin1.json').write_text(json.dumps(admin1, ensure_ascii=False))

--- a/bin/download_data.py
+++ b/bin/download_data.py
@@ -8,6 +8,7 @@ import httpx
 
 # Data files to download
 DOWNLOADS = [
+    'http://download.geonames.org/export/dump/admin1CodesASCII.txt',
     'http://download.geonames.org/export/dump/cities500.zip',
     'http://download.geonames.org/export/dump/cities1000.zip',
     'http://download.geonames.org/export/dump/cities5000.zip',

--- a/geonamescache/__init__.py
+++ b/geonamescache/__init__.py
@@ -10,6 +10,8 @@ from collections.abc import Mapping
 from typing import Any, ClassVar, TypeVar
 
 from geonamescache.types import (
+    Admin1,
+    Admin1CodeStr,
     City,
     CitySearchAttribute,
     Continent,
@@ -27,6 +29,7 @@ TDict = TypeVar('TDict', bound=Mapping[str, Any])
 
 
 class GeonamesCache:
+    admin1: dict[Admin1CodeStr, Admin1] | None = None
     continents: dict[ContinentCode, Continent] | None = None
     countries: dict[ISOStr, Country] | None = None
     cities: dict[GeoNameIdStr, City] | None = None
@@ -46,6 +49,10 @@ class GeonamesCache:
 
     def get_countries(self) -> dict[ISOStr, Country]:
         return self._load_data(self.countries, 'countries.json')
+
+    def get_admin1_codes(self) -> dict[Admin1CodeStr, Admin1]:
+        """Get first-level administrative divisions keyed by <countrycode>.<admin1code>, e. g. US.CA."""
+        return self._load_data(self.admin1, 'admin1.json')
 
     def get_us_states(self) -> dict[USStateCode, USState]:
         return self._load_data(self.us_states, 'us_states.json')

--- a/geonamescache/types.py
+++ b/geonamescache/types.py
@@ -8,6 +8,7 @@ else:
 
 GeoNameIdStr = str
 ISOStr = str
+Admin1CodeStr = str
 ContinentCode = Literal["AF", "AN", "AS", "EU", "NA", "OC", "SA"]
 USStateCode = Literal[
     "AK",
@@ -165,6 +166,12 @@ class Continent(TypedDict):
     srtm3: int
     wikipediaURL: str
     cc2: NotRequired[str]
+
+
+class Admin1(TypedDict):
+    asciiname: str
+    geonameid: int
+    name: str
 
 
 class City(TypedDict):

--- a/tests/test_geonamescache.py
+++ b/tests/test_geonamescache.py
@@ -3,6 +3,26 @@ from geonamescache import GeonamesCache
 gc = GeonamesCache()
 
 
+def test_get_admin1_codes():
+    admin1 = gc.get_admin1_codes()
+    assert len(admin1) > 3000
+    for key, name, geonameid in (
+        ('US.CA', 'California', 5332921),
+        ('ES.51', 'Andalusia', 2593109),
+    ):
+        assert name == admin1[key]['name']
+        assert geonameid == admin1[key]['geonameid']
+
+
+def test_admin1_code_resolves_city_reference():
+    # Cities store countrycode and admin1code separately, the composite
+    # admin1 key allows resolving these references.
+    city = gc.get_cities()['5368361']
+    assert 'Los Angeles' == city['name']
+    key = f"{city['countrycode']}.{city['admin1code']}"
+    assert 'California' == gc.get_admin1_codes()[key]['name']
+
+
 def test_get_countries_by_names():
     # Length of get_countries_by_names dict and get_countries dict must be
     # the same, unless country names wouldn't be unique.


### PR DESCRIPTION
## Summary

Adds support for the GeoNames first-level administrative division dataset (`admin1CodesASCII.txt`), exposed via a new `GeonamesCache.get_admin1_codes()` method.

## Design

The returned dictionary is keyed by the composite code `<countrycode>.<admin1code>`, e. g. `US.CA`, matching the format used in the GeoNames source file. This is the headline benefit of the composite key: city records store `countrycode` and `admin1code` as separate fields, so their admin1 references are directly resolvable:

```python
import geonamescache

gc = geonamescache.GeonamesCache()
city = gc.get_cities()['5368361']  # Los Angeles
admin1 = gc.get_admin1_codes()[f"{city['countrycode']}.{city['admin1code']}"]
print(admin1['name'])  # California
```

Each record contains `name`, `asciiname` and `geonameid`.

## Changes

* `bin/download_data.py`: download `admin1CodesASCII.txt`
* `bin/admin1.py`: new generator producing `admin1.json`
* `Makefile`: run the new generator in the `json` target
* `geonamescache/types.py`: new `Admin1` TypedDict and `Admin1CodeStr` key alias
* `geonamescache/__init__.py`: new `get_admin1_codes()` method
* Tests, README and CHANGELOG updated

## Verification

* `pytest`: all new and existing tests pass (the new tests cover key lookup, dataset size and resolving a city's admin1 reference)
* `ruff check` and `mypy geonamescache tests` pass